### PR TITLE
[YW2-117] AccessToken Resolving + 봉사자 정보 매핑

### DIFF
--- a/src/app/api/src/main/kotlin/yapp/be/apiapplication/shelter/controller/ShelterController.kt
+++ b/src/app/api/src/main/kotlin/yapp/be/apiapplication/shelter/controller/ShelterController.kt
@@ -1,0 +1,26 @@
+package yapp.be.apiapplication.shelter.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import yapp.be.apiapplication.system.security.resolver.VolunteerAuthentication
+import yapp.be.apiapplication.system.security.resolver.VolunteerAuthenticationInfo
+
+@RestController
+@RequestMapping("/v1/shelter")
+class ShelterController {
+
+    @GetMapping("/{shelterId}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(
+        summary = "보호소 조회"
+    )
+    fun editShelterProfileImage(
+        @PathVariable shelterId: Long,
+        @VolunteerAuthentication volunteerInfo: VolunteerAuthenticationInfo
+    ): ResponseEntity<String> {
+        println("${volunteerInfo.volunteerId} ${volunteerInfo.email.value}")
+        return ResponseEntity.ok("Hello")
+    }
+}

--- a/src/app/api/src/main/kotlin/yapp/be/apiapplication/system/config/SecurityConfig.kt
+++ b/src/app/api/src/main/kotlin/yapp/be/apiapplication/system/config/SecurityConfig.kt
@@ -65,6 +65,8 @@ class SecurityConfig(
             it.requestMatchers(
                 AntPathRequestMatcher("/v1/shelter/admin/**")
             ).hasAuthority(Role.SHELTER.name)
+            it.anyRequest()
+                .hasAuthority(Role.VOLUNTEER.name)
         }
 
         http

--- a/src/app/api/src/main/kotlin/yapp/be/apiapplication/system/config/SwaggerConfig.kt
+++ b/src/app/api/src/main/kotlin/yapp/be/apiapplication/system/config/SwaggerConfig.kt
@@ -12,6 +12,7 @@ import org.springdoc.core.utils.SpringDocUtils
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import yapp.be.apiapplication.system.security.resolver.ShelterUserAuthenticationInfo
+import yapp.be.apiapplication.system.security.resolver.VolunteerAuthenticationInfo
 
 @Configuration
 @SecurityScheme(
@@ -25,7 +26,7 @@ import yapp.be.apiapplication.system.security.resolver.ShelterUserAuthentication
 class SwaggerConfig {
 
     init {
-        val ignoreTypes = setOf<Class<*>>(ShelterUserAuthenticationInfo::class.java).toTypedArray()
+        val ignoreTypes = setOf<Class<*>>(ShelterUserAuthenticationInfo::class.java, VolunteerAuthenticationInfo::class.java).toTypedArray()
         SpringDocUtils.getConfig().addRequestWrapperToIgnore(*ignoreTypes)
     }
     @Bean

--- a/src/app/api/src/main/kotlin/yapp/be/apiapplication/system/config/WebConfig.kt
+++ b/src/app/api/src/main/kotlin/yapp/be/apiapplication/system/config/WebConfig.kt
@@ -5,9 +5,11 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 import yapp.be.apiapplication.system.security.resolver.ShelterUserAuthenticationInfoArgumentResolver
+import yapp.be.apiapplication.system.security.resolver.VolunteerAuthenticationInfoArgumentResolver
 
 @Configuration
 class WebConfig(
+    private val volunteerAuthenticationInfoArgumentResolver: VolunteerAuthenticationInfoArgumentResolver,
     private val shelterUserAuthenticationInfoArgumentResolver: ShelterUserAuthenticationInfoArgumentResolver
 ) : WebMvcConfigurer {
     override fun addCorsMappings(registry: CorsRegistry) {
@@ -18,6 +20,11 @@ class WebConfig(
     }
 
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
-        resolvers.add(shelterUserAuthenticationInfoArgumentResolver)
+        resolvers.addAll(
+            listOf(
+                volunteerAuthenticationInfoArgumentResolver,
+                shelterUserAuthenticationInfoArgumentResolver
+            )
+        )
     }
 }

--- a/src/app/api/src/main/kotlin/yapp/be/apiapplication/system/security/resolver/VolunteerAuthentication.kt
+++ b/src/app/api/src/main/kotlin/yapp/be/apiapplication/system/security/resolver/VolunteerAuthentication.kt
@@ -2,4 +2,4 @@ package yapp.be.apiapplication.system.security.resolver
 
 @Target(AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.TYPE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class ShelterUserAuthentication
+annotation class VolunteerAuthentication

--- a/src/app/api/src/main/kotlin/yapp/be/apiapplication/system/security/resolver/VolunteerAuthenticationInfo.kt
+++ b/src/app/api/src/main/kotlin/yapp/be/apiapplication/system/security/resolver/VolunteerAuthenticationInfo.kt
@@ -1,0 +1,8 @@
+package yapp.be.apiapplication.system.security.resolver
+
+import yapp.be.model.Email
+
+data class VolunteerAuthenticationInfo(
+    val volunteerId: Long,
+    val email: Email
+)

--- a/src/app/api/src/main/kotlin/yapp/be/apiapplication/system/security/resolver/VolunteerAuthenticationInfoArgumentResolver.kt
+++ b/src/app/api/src/main/kotlin/yapp/be/apiapplication/system/security/resolver/VolunteerAuthenticationInfoArgumentResolver.kt
@@ -1,0 +1,34 @@
+package yapp.be.apiapplication.system.security.resolver
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.MethodParameter
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+import yapp.be.apiapplication.system.security.CustomUserDetails
+import yapp.be.model.Email
+
+@Configuration
+class VolunteerAuthenticationInfoArgumentResolver : HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return parameter.getParameterAnnotation(VolunteerAuthentication::class.java) != null &&
+            parameter.parameterType == VolunteerAuthenticationInfo::class.java
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?
+    ): Any {
+        val authenticationToken = SecurityContextHolder.getContext().authentication
+        val principal = authenticationToken.principal as CustomUserDetails
+        return VolunteerAuthenticationInfo(
+            volunteerId = principal.id!!,
+            email = Email(principal.username)
+
+        )
+    }
+}

--- a/src/app/api/src/main/resources/application-oauth-dev.yml
+++ b/src/app/api/src/main/resources/application-oauth-dev.yml
@@ -19,4 +19,4 @@ spring:
                         user-info-uri: https://kapi.kakao.com/v2/user/me
                         user-name-attribute: id
 oauth:
-    redirect-url: "http://localhost:3000/volunteer/redirect"
+    redirect-url: ${DEV_FRONT_REDIRECT_URL:http://localhost:3000/volunteer/redirect}


### PR DESCRIPTION
<!--
1. 어떤 작업을 했는지 : 간단하게 설명
2. 자세한 설명 : 필요하다면
3. 영향범위 : 영향받은 모듈
4. 데이터베이스 DDL 변경사항이 필요하다면 반드시 SQL을 작성해주세요
-->

## 🎯 작업 내역
- ArgumentResolver 추가
- accessToken을 파싱하여, VolunteerAuthenticationInfo에 매핑
- 회원가입, 로그인 , 관리자를 제외하고 기본적으로 모두 봉사자 Role 확인

## 📜 Jira 티켓
[YW2-117](https://yapp22-web2.atlassian.net/browse/YW2-117)

## 📁 영향범위 (모듈)
app > api

## 📒 SQL (DDL 변경사항 있는 경우만)

_---
Resolves: # See also: #_
