### PR TITLE
[YW2-120] 회원가입 Flow 개선

### DIFF
--- a/src/app/api/src/main/kotlin/yapp/be/apiapplication/auth/service/VolunteerAuthApplicationService.kt
+++ b/src/app/api/src/main/kotlin/yapp/be/apiapplication/auth/service/VolunteerAuthApplicationService.kt
@@ -12,6 +12,7 @@ import yapp.be.apiapplication.system.security.properties.JwtConfigProperties
 import yapp.be.domain.port.inbound.*
 import yapp.be.domain.port.inbound.model.CreateUserCommand
 import yapp.be.exceptions.CustomException
+import java.time.Duration
 
 @Service
 class VolunteerAuthApplicationService(
@@ -52,7 +53,7 @@ class VolunteerAuthApplicationService(
         saveTokenUseCase.saveToken(
             accessToken = tokens[0],
             refreshToken = tokens[1],
-            expire = jwtConfigProperties.refresh.expire
+            expire = Duration.ofMillis(jwtConfigProperties.refresh.expire)
         )
 
         deleteTokenUseCase.deleteTokenByAuthToken(authToken = reqDto.authToken)

--- a/src/app/api/src/main/kotlin/yapp/be/apiapplication/auth/service/VolunteerAuthApplicationService.kt
+++ b/src/app/api/src/main/kotlin/yapp/be/apiapplication/auth/service/VolunteerAuthApplicationService.kt
@@ -21,15 +21,21 @@ class VolunteerAuthApplicationService(
     private val createVolunteerUseCase: CreateVolunteerUseCase,
     private val checkVolunteerUseCase: CheckVolunteerUseCase,
     private val saveTokenUseCase: SaveTokenUseCase,
+    private val getOAuthNonMemberInfoUseCase: GetOAuthNonMemberInfoUseCase,
     private val jwtConfigProperties: JwtConfigProperties,
 ) {
     @Transactional
     fun register(dto: SignUpUserRequestDto): SignUpUserWithEssentialInfoResponseDto {
+
+        val oAuthNonMemberInfo = getOAuthNonMemberInfoUseCase.get(dto.email)
+            ?: throw CustomException(ApiExceptionType.UNAUTHENTICATED_EXCEPTION, "로그인 유효시간이 만료되었거나, 비정상적인 접근입니다.")
+
         val user = createVolunteerUseCase.create(
             CreateUserCommand(
                 nickname = dto.nickname,
                 email = dto.email,
-                phone = dto.phoneNumber
+                phone = dto.phoneNumber,
+                oAuthUserIdentifier = oAuthNonMemberInfo
             )
         )
 

--- a/src/domain/auth/src/main/kotlin/yapp.be.domain/port/inbound/GetOAuthNonMemberInfoUseCase.kt
+++ b/src/domain/auth/src/main/kotlin/yapp.be.domain/port/inbound/GetOAuthNonMemberInfoUseCase.kt
@@ -1,0 +1,7 @@
+package yapp.be.domain.port.inbound
+
+import yapp.be.model.Email
+
+interface GetOAuthNonMemberInfoUseCase {
+    fun get(email: Email): String?
+}

--- a/src/domain/auth/src/main/kotlin/yapp.be.domain/port/inbound/SaveOAuthNonMemberInfoUseCase.kt
+++ b/src/domain/auth/src/main/kotlin/yapp.be.domain/port/inbound/SaveOAuthNonMemberInfoUseCase.kt
@@ -4,10 +4,6 @@ import yapp.be.model.Email
 import java.time.Duration
 
 interface SaveOAuthNonMemberInfoUseCase {
-
-    fun getOAuthNonMemberInfo(
-        email: Email
-    ): String?
     fun saveOAuthNonMemberInfo(
         email: Email,
         oAuthIdentifier: String,

--- a/src/domain/auth/src/main/kotlin/yapp.be.domain/port/inbound/SaveOAuthNonMemberInfoUseCase.kt
+++ b/src/domain/auth/src/main/kotlin/yapp.be.domain/port/inbound/SaveOAuthNonMemberInfoUseCase.kt
@@ -1,0 +1,16 @@
+package yapp.be.domain.port.inbound
+
+import yapp.be.model.Email
+import java.time.Duration
+
+interface SaveOAuthNonMemberInfoUseCase {
+
+    fun getOAuthNonMemberInfo(
+        email: Email
+    ): String?
+    fun saveOAuthNonMemberInfo(
+        email: Email,
+        oAuthIdentifier: String,
+        duration: Duration
+    )
+}

--- a/src/domain/auth/src/main/kotlin/yapp.be.domain/port/inbound/SaveTokenUseCase.kt
+++ b/src/domain/auth/src/main/kotlin/yapp.be.domain/port/inbound/SaveTokenUseCase.kt
@@ -1,16 +1,18 @@
 package yapp.be.domain.port.inbound
 
+import java.time.Duration
+
 interface SaveTokenUseCase {
 
     fun saveTokensWithAuthToken(
         authToken: String,
         accessToken: String,
         refreshToken: String,
-        authTokenExpire: Long
+        authTokenExpire: Duration
     )
     fun saveToken(
         accessToken: String,
         refreshToken: String,
-        expire: Long,
+        expire: Duration,
     )
 }

--- a/src/domain/auth/src/main/kotlin/yapp.be.domain/port/outbound/OAuthNonMemberInfoCommandHandler.kt
+++ b/src/domain/auth/src/main/kotlin/yapp.be.domain/port/outbound/OAuthNonMemberInfoCommandHandler.kt
@@ -1,0 +1,8 @@
+package yapp.be.domain.port.outbound
+
+import yapp.be.model.Email
+import java.time.Duration
+
+interface OAuthNonMemberInfoCommandHandler {
+    fun save(email: Email, oAuthIdentifier: String, duration: Duration)
+}

--- a/src/domain/auth/src/main/kotlin/yapp.be.domain/port/outbound/OAuthNonMemberInfoQueryHandler.kt
+++ b/src/domain/auth/src/main/kotlin/yapp.be.domain/port/outbound/OAuthNonMemberInfoQueryHandler.kt
@@ -1,0 +1,7 @@
+package yapp.be.domain.port.outbound
+
+import yapp.be.model.Email
+
+interface OAuthNonMemberInfoQueryHandler {
+    fun get(email: Email): String?
+}

--- a/src/domain/auth/src/main/kotlin/yapp.be.domain/port/outbound/TokenCommandHandler.kt
+++ b/src/domain/auth/src/main/kotlin/yapp.be.domain/port/outbound/TokenCommandHandler.kt
@@ -1,10 +1,12 @@
 package yapp.be.domain.port.outbound
 
+import java.time.Duration
+
 interface TokenCommandHandler {
 
     fun deleteTokenByAuthToken(authToken: String)
     fun deleteToken(accessToken: String)
-    fun saveToken(accessToken: String, refreshToken: String, expire: Long)
+    fun saveToken(accessToken: String, refreshToken: String, duration: Duration)
 
-    fun saveTokensWithAuthToken(authToken: String, accessToken: String, refreshToken: String, expire: Long)
+    fun saveTokensWithAuthToken(authToken: String, accessToken: String, refreshToken: String, duration: Duration)
 }

--- a/src/domain/auth/src/main/kotlin/yapp.be.domain/service/GetOAuthNonMemberInfoDomainService.kt
+++ b/src/domain/auth/src/main/kotlin/yapp.be.domain/service/GetOAuthNonMemberInfoDomainService.kt
@@ -1,0 +1,15 @@
+package yapp.be.domain.service
+
+import org.springframework.stereotype.Service
+import yapp.be.domain.port.inbound.GetOAuthNonMemberInfoUseCase
+import yapp.be.domain.port.outbound.OAuthNonMemberInfoQueryHandler
+import yapp.be.model.Email
+
+@Service
+class GetOAuthNonMemberInfoDomainService(
+    private val oAuthNonMemberInfoQueryHandler: OAuthNonMemberInfoQueryHandler
+) : GetOAuthNonMemberInfoUseCase {
+    override fun get(email: Email): String? {
+        return oAuthNonMemberInfoQueryHandler.get(email)
+    }
+}

--- a/src/domain/auth/src/main/kotlin/yapp.be.domain/service/SaveOAuthNonMemberInfoDomainService.kt
+++ b/src/domain/auth/src/main/kotlin/yapp.be.domain/service/SaveOAuthNonMemberInfoDomainService.kt
@@ -3,18 +3,13 @@ package yapp.be.domain.service
 import org.springframework.stereotype.Service
 import yapp.be.domain.port.inbound.SaveOAuthNonMemberInfoUseCase
 import yapp.be.domain.port.outbound.OAuthNonMemberInfoCommandHandler
-import yapp.be.domain.port.outbound.OAuthNonMemberInfoQueryHandler
 import yapp.be.model.Email
 import java.time.Duration
 
 @Service
 class SaveOAuthNonMemberInfoDomainService(
-    private val oAuthNonMemberInfoQueryHandler: OAuthNonMemberInfoQueryHandler,
     private val oAuthNonMemberInfoCommandHandler: OAuthNonMemberInfoCommandHandler
 ) : SaveOAuthNonMemberInfoUseCase {
-    override fun getOAuthNonMemberInfo(email: Email): String? {
-        return oAuthNonMemberInfoQueryHandler.get(email)
-    }
 
     override fun saveOAuthNonMemberInfo(email: Email, oAuthIdentifier: String, duration: Duration) {
         return oAuthNonMemberInfoCommandHandler.save(

--- a/src/domain/auth/src/main/kotlin/yapp.be.domain/service/SaveOAuthNonMemberInfoDomainService.kt
+++ b/src/domain/auth/src/main/kotlin/yapp.be.domain/service/SaveOAuthNonMemberInfoDomainService.kt
@@ -1,0 +1,26 @@
+package yapp.be.domain.service
+
+import org.springframework.stereotype.Service
+import yapp.be.domain.port.inbound.SaveOAuthNonMemberInfoUseCase
+import yapp.be.domain.port.outbound.OAuthNonMemberInfoCommandHandler
+import yapp.be.domain.port.outbound.OAuthNonMemberInfoQueryHandler
+import yapp.be.model.Email
+import java.time.Duration
+
+@Service
+class SaveOAuthNonMemberInfoDomainService(
+    private val oAuthNonMemberInfoQueryHandler: OAuthNonMemberInfoQueryHandler,
+    private val oAuthNonMemberInfoCommandHandler: OAuthNonMemberInfoCommandHandler
+) : SaveOAuthNonMemberInfoUseCase {
+    override fun getOAuthNonMemberInfo(email: Email): String? {
+        return oAuthNonMemberInfoQueryHandler.get(email)
+    }
+
+    override fun saveOAuthNonMemberInfo(email: Email, oAuthIdentifier: String, duration: Duration) {
+        return oAuthNonMemberInfoCommandHandler.save(
+            email = email,
+            oAuthIdentifier = oAuthIdentifier,
+            duration = duration
+        )
+    }
+}

--- a/src/domain/auth/src/main/kotlin/yapp.be.domain/service/SaveTokenDomainService.kt
+++ b/src/domain/auth/src/main/kotlin/yapp.be.domain/service/SaveTokenDomainService.kt
@@ -3,29 +3,30 @@ package yapp.be.domain.service
 import org.springframework.stereotype.Service
 import yapp.be.domain.port.inbound.SaveTokenUseCase
 import yapp.be.domain.port.outbound.TokenCommandHandler
+import java.time.Duration
 
 @Service
 class SaveTokenDomainService(
     private val tokenCommandHandler: TokenCommandHandler,
 ) : SaveTokenUseCase {
-    override fun saveTokensWithAuthToken(authToken: String, accessToken: String, refreshToken: String, authTokenExpire: Long) {
+    override fun saveTokensWithAuthToken(authToken: String, accessToken: String, refreshToken: String, authTokenExpire: Duration) {
         tokenCommandHandler.saveTokensWithAuthToken(
             authToken = authToken,
             accessToken = accessToken,
             refreshToken = refreshToken,
-            expire = authTokenExpire
+            duration = authTokenExpire
         )
     }
 
     override fun saveToken(
         accessToken: String,
         refreshToken: String,
-        expire: Long,
+        expire: Duration,
     ) {
         tokenCommandHandler.saveToken(
             accessToken = accessToken,
             refreshToken = refreshToken,
-            expire = expire
+            duration = expire
         )
     }
 }

--- a/src/domain/volunteer/src/main/kotlin/yapp.be.domain/model/Volunteer.kt
+++ b/src/domain/volunteer/src/main/kotlin/yapp.be.domain/model/Volunteer.kt
@@ -11,6 +11,7 @@ data class Volunteer(
     val phone: String,
     val role: Role = Role.VOLUNTEER,
     val oAuthType: OAuthType = OAuthType.KAKAO,
+    val oAuthIdentifier: String,
     val oAuthAccessToken: String? = null,
     val oAuthRefreshToken: String? = null,
     val isDeleted: Boolean = false,

--- a/src/domain/volunteer/src/main/kotlin/yapp.be.domain/port/inbound/CheckVolunteerUseCase.kt
+++ b/src/domain/volunteer/src/main/kotlin/yapp.be.domain/port/inbound/CheckVolunteerUseCase.kt
@@ -1,6 +1,8 @@
 package yapp.be.domain.port.inbound
 
+import yapp.be.model.Email
+
 interface CheckVolunteerUseCase {
-    fun isExistByEmail(email: String): Boolean
+    fun isExistByEmail(email: Email): Boolean
     fun isExistByNickname(nickname: String): Boolean
 }

--- a/src/domain/volunteer/src/main/kotlin/yapp.be.domain/port/inbound/GetVolunteerUseCase.kt
+++ b/src/domain/volunteer/src/main/kotlin/yapp.be.domain/port/inbound/GetVolunteerUseCase.kt
@@ -1,7 +1,8 @@
 package yapp.be.domain.port.inbound
 
 import yapp.be.domain.model.Volunteer
+import yapp.be.model.Email
 
 interface GetVolunteerUseCase {
-    fun getByEmail(email: String): Volunteer
+    fun getByEmail(email: Email): Volunteer
 }

--- a/src/domain/volunteer/src/main/kotlin/yapp.be.domain/port/inbound/model/CreateUserCommand.kt
+++ b/src/domain/volunteer/src/main/kotlin/yapp.be.domain/port/inbound/model/CreateUserCommand.kt
@@ -6,4 +6,5 @@ data class CreateUserCommand(
     val nickname: String,
     val email: Email,
     val phone: String,
+    val oAuthUserIdentifier: String
 )

--- a/src/domain/volunteer/src/main/kotlin/yapp.be.domain/service/CheckVolunteerDomainService.kt
+++ b/src/domain/volunteer/src/main/kotlin/yapp.be.domain/service/CheckVolunteerDomainService.kt
@@ -4,14 +4,15 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import yapp.be.domain.port.inbound.CheckVolunteerUseCase
 import yapp.be.domain.port.outbound.VolunteerQueryHandler
+import yapp.be.model.Email
 
 @Service
 class CheckVolunteerDomainService(
     private val volunteerQueryHandler: VolunteerQueryHandler
 ) : CheckVolunteerUseCase {
     @Transactional(readOnly = true)
-    override fun isExistByEmail(email: String): Boolean {
-        return volunteerQueryHandler.isExistByEmail(email)
+    override fun isExistByEmail(email: Email): Boolean {
+        return volunteerQueryHandler.isExistByEmail(email.value)
     }
     @Transactional(readOnly = true)
     override fun isExistByNickname(nickname: String): Boolean {

--- a/src/domain/volunteer/src/main/kotlin/yapp.be.domain/service/CreateVolunteerDomainService.kt
+++ b/src/domain/volunteer/src/main/kotlin/yapp.be.domain/service/CreateVolunteerDomainService.kt
@@ -17,6 +17,7 @@ class CreateVolunteerDomainService(
             nickname = command.nickname,
             email = command.email,
             phone = command.phone,
+            oAuthIdentifier = command.oAuthUserIdentifier
         )
         return volunteerCommandHandler.save(volunteer)
     }

--- a/src/domain/volunteer/src/main/kotlin/yapp.be.domain/service/GetVolunteerDomainService.kt
+++ b/src/domain/volunteer/src/main/kotlin/yapp.be.domain/service/GetVolunteerDomainService.kt
@@ -5,13 +5,14 @@ import org.springframework.transaction.annotation.Transactional
 import yapp.be.domain.model.Volunteer
 import yapp.be.domain.port.inbound.GetVolunteerUseCase
 import yapp.be.domain.port.outbound.VolunteerQueryHandler
+import yapp.be.model.Email
 
 @Service
 class GetVolunteerDomainService(
     private val volunteerQueryHandler: VolunteerQueryHandler
 ) : GetVolunteerUseCase {
     @Transactional(readOnly = true)
-    override fun getByEmail(email: String): Volunteer {
-        return volunteerQueryHandler.findByEmail(email)
+    override fun getByEmail(email: Email): Volunteer {
+        return volunteerQueryHandler.findByEmail(email.value)
     }
 }

--- a/src/domain/volunteer/src/main/kotlin/yapp.be.domain/service/ModifyVolunteerDomainService.kt
+++ b/src/domain/volunteer/src/main/kotlin/yapp.be.domain/service/ModifyVolunteerDomainService.kt
@@ -15,16 +15,17 @@ class ModifyVolunteerDomainService(
 ) : ModifyVolunteerUseCase {
     @Transactional
     override fun updateUserToken(command: ModifyUserTokenCommand): Volunteer {
-        val userEntity = volunteerQueryHandler.findById(command.userId)
+        val user = volunteerQueryHandler.findById(command.userId)
         val updatedVolunteer = Volunteer(
             id = command.userId,
-            email = userEntity.email,
-            role = userEntity.role,
-            oAuthType = userEntity.oAuthType,
+            email = user.email,
+            role = user.role,
+            oAuthType = user.oAuthType,
+            oAuthIdentifier = user.oAuthIdentifier,
             oAuthAccessToken = command.oAuth2AccessToken,
             oAuthRefreshToken = command.oAuth2RefreshToken,
-            nickname = userEntity.nickname,
-            phone = userEntity.phone,
+            nickname = user.nickname,
+            phone = user.phone,
         )
         return volunteerCommandHandler.saveToken(updatedVolunteer)
     }

--- a/src/infrastructure/redis/build.gradle.kts
+++ b/src/infrastructure/redis/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     implementation("it.ozimov:embedded-redis:$embeddedRedisVersion")
 
     implementation(project(":auth"))
+    implementation(project(":common"))
 }
 
 tasks.named<BootJar>("bootJar") {

--- a/src/infrastructure/redis/src/main/kotlin/yapp/be/redis/repository/OAuthNonMemberInfoRepository.kt
+++ b/src/infrastructure/redis/src/main/kotlin/yapp/be/redis/repository/OAuthNonMemberInfoRepository.kt
@@ -1,0 +1,25 @@
+package yapp.be.redis.repository
+
+import org.springframework.stereotype.Component
+import yapp.be.domain.port.outbound.OAuthNonMemberInfoCommandHandler
+import yapp.be.domain.port.outbound.OAuthNonMemberInfoQueryHandler
+import yapp.be.model.Email
+import java.time.Duration
+
+@Component
+class OAuthNonMemberInfoRepository(
+    private val redisHandler: RedisHandler
+) : OAuthNonMemberInfoQueryHandler, OAuthNonMemberInfoCommandHandler {
+
+    override fun get(email: Email): String? {
+        return redisHandler.getData(email.value)
+    }
+
+    override fun save(email: Email, oAuthIdentifier: String, duration: Duration) {
+        redisHandler.setDataExpire(
+            key = email.value,
+            value = oAuthIdentifier,
+            duration = duration
+        )
+    }
+}

--- a/src/infrastructure/redis/src/main/kotlin/yapp/be/redis/repository/RedisHandler.kt
+++ b/src/infrastructure/redis/src/main/kotlin/yapp/be/redis/repository/RedisHandler.kt
@@ -4,7 +4,7 @@ import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Repository
 import java.time.Duration
 @Repository
-class RedisRepository(
+class RedisHandler(
     private val stringRedisTemplate: StringRedisTemplate
 ) {
     fun getData(key: String): String? {
@@ -21,11 +21,11 @@ class RedisRepository(
         valueOperations[key] = value
     }
 
-    fun setDataExpire(key: String, value: String, duration: Long) {
+    fun setDataExpire(key: String, value: String, duration: Duration) {
         if (stringRedisTemplate.hasKey(key)) {
             stringRedisTemplate.delete(key)
         }
-        stringRedisTemplate.opsForValue().set(key, value, Duration.ofSeconds(duration))
+        stringRedisTemplate.opsForValue().set(key, value, duration)
     }
 
     fun deleteData(key: String) {

--- a/src/infrastructure/redis/src/main/kotlin/yapp/be/redis/repository/TokenRepository.kt
+++ b/src/infrastructure/redis/src/main/kotlin/yapp/be/redis/repository/TokenRepository.kt
@@ -3,36 +3,37 @@ package yapp.be.redis.repository
 import org.springframework.stereotype.Component
 import yapp.be.domain.port.outbound.TokenCommandHandler
 import yapp.be.domain.port.outbound.TokenQueryHandler
+import java.time.Duration
 
 @Component
 class TokenRepository(
-    private val redisRepository: RedisRepository,
+    private val redisHandler: RedisHandler,
 ) : TokenQueryHandler, TokenCommandHandler {
 
     override fun getTokensByAuthToken(authToken: String): String? {
-        return redisRepository.getData(authToken)
+        return redisHandler.getData(authToken)
     }
-    override fun saveToken(accessToken: String, refreshToken: String, expire: Long) {
-        redisRepository.setDataExpire(
+    override fun saveToken(accessToken: String, refreshToken: String, duration: Duration) {
+        redisHandler.setDataExpire(
             key = accessToken,
             value = refreshToken,
-            duration = expire
+            duration = duration
         )
     }
 
-    override fun saveTokensWithAuthToken(authToken: String, accessToken: String, refreshToken: String, expire: Long) {
-        redisRepository.setDataExpire(
+    override fun saveTokensWithAuthToken(authToken: String, accessToken: String, refreshToken: String, duration: Duration) {
+        redisHandler.setDataExpire(
             key = authToken,
             value = "$accessToken,$refreshToken",
-            duration = expire
+            duration = duration
         )
     }
 
     override fun deleteTokenByAuthToken(authToken: String) {
-        redisRepository.deleteData(authToken)
+        redisHandler.deleteData(authToken)
     }
 
     override fun deleteToken(accessToken: String) {
-        redisRepository.deleteData(accessToken)
+        redisHandler.deleteData(accessToken)
     }
 }

--- a/src/infrastructure/storage/src/main/kotlin/yapp/be/storage/jpa/volunteer/model/VolunteerEntity.kt
+++ b/src/infrastructure/storage/src/main/kotlin/yapp/be/storage/jpa/volunteer/model/VolunteerEntity.kt
@@ -24,6 +24,8 @@ class VolunteerEntity(
     @Column(name = "o_auth_type")
     @Enumerated(EnumType.STRING)
     var oAuthType: OAuthType = OAuthType.KAKAO,
+    @Column(name = "o_auth_identifier")
+    val oAuthIdentifier: String,
     @Column(name = "o_auth_access_token")
     var oAuthAccessToken: String? = null,
     @Column(name = "o_auth_refresh_token")

--- a/src/infrastructure/storage/src/main/kotlin/yapp/be/storage/jpa/volunteer/model/mappers/VolunteerModelMapper.kt
+++ b/src/infrastructure/storage/src/main/kotlin/yapp/be/storage/jpa/volunteer/model/mappers/VolunteerModelMapper.kt
@@ -12,6 +12,7 @@ fun Volunteer.toEntityModel(): VolunteerEntity {
         role = this.role,
         phone = this.phone,
         oAuthType = this.oAuthType,
+        oAuthIdentifier = this.oAuthIdentifier,
         oAuthAccessToken = this.oAuthAccessToken,
         oAuthRefreshToken = this.oAuthRefreshToken,
         deleted = this.isDeleted,
@@ -26,6 +27,7 @@ fun VolunteerEntity.toDomainModel(): Volunteer {
         role = this.role,
         phone = this.phone,
         oAuthType = this.oAuthType,
+        oAuthIdentifier = this.oAuthIdentifier,
         oAuthAccessToken = this.oAuthAccessToken,
         oAuthRefreshToken = this.oAuthRefreshToken,
         isDeleted = this.deleted

--- a/src/infrastructure/storage/src/main/resources/sql/1.ddl.sql
+++ b/src/infrastructure/storage/src/main/resources/sql/1.ddl.sql
@@ -4,6 +4,7 @@ CREATE TABLE `volunteer`
 (
     `id`                                  bigint       not null primary key auto_increment,
     `o_auth_type`                         varchar(20)  not null,
+    `o_auth_identifier`                   varchar(50)  not null,
     `o_auth_access_token`                 varchar(100) null,
     `o_auth_refresh_token`                 varchar(100) null,
     `is_deleted`                          boolean      not null,


### PR DESCRIPTION
<!--
1. 어떤 작업을 했는지 : 간단하게 설명
2. 자세한 설명 : 필요하다면
3. 영향범위 : 영향받은 모듈
4. 데이터베이스 DDL 변경사항이 필요하다면 반드시 SQL을 작성해주세요
-->

## 🎯 작업 내역
- oAuth시 비회원이면, 2단계를 걸처서 회원가입을 하게 됨
   - 추가정보를 받을 때, 1단계를 건너뛰어도 막지않고 있었음
- 첫 번째 단계에서 얻은정보를 Redis에 TTL과 함꼐 저장하고 이를 통해서 검증
   - 없다면 팅겨냄    

## 📜 Jira 티켓
[YW2-120](https://yapp22-web2.atlassian.net/jira/software/projects/YW2/boards/3?selectedIssue=YW2-120)

## 📁 영향범위 (모듈)
- app > api
- domain > volunteer
- doman > auth
- storage> infrastructure

## 📒 SQL (DDL 변경사항 있는 경우만)
- volunteer 
   - ```
         o_auth_identifier varchar(50) notnull 
     ``` 

_---
Resolves: # See also: #_
