### PR TITLE
[YW2-190] 전날 완료된 봉사이벤트 상태 변경 및 대기큐 삭제

### DIFF
--- a/src/app/api/src/main/kotlin/yapp/be/ApiApplication.kt
+++ b/src/app/api/src/main/kotlin/yapp/be/ApiApplication.kt
@@ -4,9 +4,11 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.EnableAspectJAutoProxy
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @EnableAspectJAutoProxy
+@EnableScheduling
 @ConfigurationPropertiesScan
 class ApiApplication
 

--- a/src/app/api/src/main/kotlin/yapp/be/apiapplication/shelter/scheduler/VolunteerEventScheduler.kt
+++ b/src/app/api/src/main/kotlin/yapp/be/apiapplication/shelter/scheduler/VolunteerEventScheduler.kt
@@ -1,0 +1,30 @@
+package yapp.be.apiapplication.shelter.scheduler
+
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import yapp.be.domain.service.EditVolunteerEventDomainService
+import yapp.be.domain.service.GetVolunteerEventDomainService
+import yapp.be.domain.service.WithdrawVolunteerEventDomainService
+import yapp.be.model.enums.volunteerevent.VolunteerEventStatus
+
+@Service
+class VolunteerEventScheduler(
+    private val editVolunteerEventDomainService: EditVolunteerEventDomainService,
+    private val getVolunteerEventDomainService: GetVolunteerEventDomainService,
+    private val withdrawVolunteerEventDomainService: WithdrawVolunteerEventDomainService,
+) {
+
+    @Scheduled(cron = "0 30 0 * * *")
+    @Transactional
+    fun updateVolunteerEventDone() {
+        val volunteerEventIds = getVolunteerEventDomainService.getVolunteerEventDone()
+        volunteerEventIds.map {
+            editVolunteerEventDomainService.editVolunteerEventStatus(
+                it.id,
+                VolunteerEventStatus.DONE
+            )
+            withdrawVolunteerEventDomainService.withdrawWaitingQueue(it.id)
+        }
+    }
+}

--- a/src/domain/volunteerEvent/src/main/kotlin/yapp.be.domain/port/inbound/EditVolunteerEventUseCase.kt
+++ b/src/domain/volunteerEvent/src/main/kotlin/yapp.be.domain/port/inbound/EditVolunteerEventUseCase.kt
@@ -2,7 +2,9 @@ package yapp.be.domain.port.inbound
 
 import yapp.be.domain.model.VolunteerEvent
 import yapp.be.domain.port.inbound.model.EditVolunteerEventCommand
+import yapp.be.model.enums.volunteerevent.VolunteerEventStatus
 
 interface EditVolunteerEventUseCase {
     fun editVolunteerEvent(command: EditVolunteerEventCommand): VolunteerEvent
+    fun editVolunteerEventStatus(volunteerEventId: Long, status: VolunteerEventStatus): VolunteerEvent
 }

--- a/src/domain/volunteerEvent/src/main/kotlin/yapp.be.domain/port/inbound/GetVolunteerEventUseCase.kt
+++ b/src/domain/volunteerEvent/src/main/kotlin/yapp.be.domain/port/inbound/GetVolunteerEventUseCase.kt
@@ -19,7 +19,7 @@ interface GetVolunteerEventUseCase {
     fun getShelterVolunteerEventStat(
         shelterId: Long
     ): ShelterUserVolunteerEventStatDto
-
+    fun getVolunteerEventDone(): List<VolunteerEvent>
     fun getAllShelterVolunteerEventHistory(
         page: Int,
         shelterId: Long,

--- a/src/domain/volunteerEvent/src/main/kotlin/yapp.be.domain/port/inbound/WithDrawVolunteerEventUseCase.kt
+++ b/src/domain/volunteerEvent/src/main/kotlin/yapp.be.domain/port/inbound/WithDrawVolunteerEventUseCase.kt
@@ -11,4 +11,8 @@ interface WithDrawVolunteerEventUseCase {
         volunteerId: Long,
         volunteerEventId: Long
     )
+
+    fun withdrawWaitingQueue(
+        volunteerEventId: Long
+    )
 }

--- a/src/domain/volunteerEvent/src/main/kotlin/yapp.be.domain/port/outbound/VolunteerEventCommandHandler.kt
+++ b/src/domain/volunteerEvent/src/main/kotlin/yapp.be.domain/port/outbound/VolunteerEventCommandHandler.kt
@@ -13,7 +13,7 @@ interface VolunteerEventCommandHandler {
     fun saveVolunteerEventJoinQueue(volunteerEventWaitingQueue: VolunteerEventWaitingQueue): VolunteerEventWaitingQueue
 
     fun saveVolunteerEventWaitingQueue(volunteerEventWaitingQueue: VolunteerEventWaitingQueue): VolunteerEventWaitingQueue
-
+    fun deleteVolunteerEventWaitingQueueByVolunteerEventId(volunteerEventId: Long)
     fun updateVolunteerEvent(volunteerEvent: VolunteerEvent): VolunteerEvent
     fun deleteVolunteerEventJoinQueueByVolunteerIdAndVolunteerEventId(
         volunteerId: Long,

--- a/src/domain/volunteerEvent/src/main/kotlin/yapp.be.domain/port/outbound/VolunteerEventQueryHandler.kt
+++ b/src/domain/volunteerEvent/src/main/kotlin/yapp.be.domain/port/outbound/VolunteerEventQueryHandler.kt
@@ -19,6 +19,8 @@ interface VolunteerEventQueryHandler {
         volunteerId: Long
     ): VolunteerVolunteerEventStatDto
 
+    fun findVolunteerEventDone(): List<VolunteerEvent>
+
     fun findShelterUserStatByShelterId(
         shelterId: Long
     ): ShelterUserVolunteerEventStatDto
@@ -26,7 +28,9 @@ interface VolunteerEventQueryHandler {
         id: Long,
         shelterId: Long
     ): VolunteerEvent
-
+    fun findById(
+        id: Long,
+    ): VolunteerEvent
     fun findAllShelterVolunteerEventByShelterId(page: Int, shelterId: Long): PagedResult<ShelterSimpleVolunteerEventDto>
     fun findAllShelterVolunteerEventByShelterIdAndStatus(page: Int, shelterId: Long, status: VolunteerEventStatus): PagedResult<ShelterSimpleVolunteerEventDto>
 

--- a/src/domain/volunteerEvent/src/main/kotlin/yapp.be.domain/service/EditVolunteerEventDomainService.kt
+++ b/src/domain/volunteerEvent/src/main/kotlin/yapp.be.domain/service/EditVolunteerEventDomainService.kt
@@ -5,10 +5,13 @@ import yapp.be.domain.model.VolunteerEvent
 import yapp.be.domain.port.inbound.EditVolunteerEventUseCase
 import yapp.be.domain.port.inbound.model.EditVolunteerEventCommand
 import yapp.be.domain.port.outbound.VolunteerEventCommandHandler
+import yapp.be.domain.port.outbound.VolunteerEventQueryHandler
+import yapp.be.model.enums.volunteerevent.VolunteerEventStatus
 
 @Service
 class EditVolunteerEventDomainService(
-    private val volunteerEventCommandHandler: VolunteerEventCommandHandler
+    private val volunteerEventCommandHandler: VolunteerEventCommandHandler,
+    private val volunteerEventQueryHandler: VolunteerEventQueryHandler,
 ) : EditVolunteerEventUseCase {
     override fun editVolunteerEvent(command: EditVolunteerEventCommand): VolunteerEvent {
 
@@ -25,6 +28,23 @@ class EditVolunteerEventDomainService(
             volunteerEventStatus = command.status
         )
 
+        return volunteerEventCommandHandler.updateVolunteerEvent(updateVolunteerEvent)
+    }
+
+    override fun editVolunteerEventStatus(volunteerEventId: Long, status: VolunteerEventStatus): VolunteerEvent {
+        val volunteerEvent = volunteerEventQueryHandler.findById(volunteerEventId)
+        val updateVolunteerEvent = VolunteerEvent(
+            id = volunteerEvent.id,
+            shelterId = volunteerEvent.shelterId,
+            title = volunteerEvent.title,
+            recruitNum = volunteerEvent.recruitNum,
+            description = volunteerEvent.description,
+            ageLimit = volunteerEvent.ageLimit,
+            startAt = volunteerEvent.startAt,
+            endAt = volunteerEvent.endAt,
+            volunteerEventCategory = volunteerEvent.volunteerEventCategory,
+            volunteerEventStatus = status
+        )
         return volunteerEventCommandHandler.updateVolunteerEvent(updateVolunteerEvent)
     }
 }

--- a/src/domain/volunteerEvent/src/main/kotlin/yapp.be.domain/service/GetVolunteerEventDomainService.kt
+++ b/src/domain/volunteerEvent/src/main/kotlin/yapp.be.domain/service/GetVolunteerEventDomainService.kt
@@ -80,6 +80,11 @@ class GetVolunteerEventDomainService(
     }
 
     @Transactional(readOnly = true)
+    override fun getVolunteerEventDone(): List<VolunteerEvent> {
+        return volunteerEventQueryHandler.findVolunteerEventDone()
+    }
+
+    @Transactional(readOnly = true)
     override fun getMemberDetailVolunteerEventInfo(shelterId: Long, volunteerId: Long, volunteerEventId: Long): DetailVolunteerEventDto {
         return volunteerEventQueryHandler.findDetailVolunteerEventInfoByIdAndShelterIdAndVolunteerId(
             id = volunteerEventId,

--- a/src/domain/volunteerEvent/src/main/kotlin/yapp.be.domain/service/WithdrawVolunteerEventDomainService.kt
+++ b/src/domain/volunteerEvent/src/main/kotlin/yapp.be.domain/service/WithdrawVolunteerEventDomainService.kt
@@ -33,4 +33,14 @@ class WithdrawVolunteerEventDomainService(
                 volunteerEventId = volunteerEventId
             )
     }
+
+    @Transactional
+    override fun withdrawWaitingQueue(
+        volunteerEventId: Long
+    ) {
+        volunteerEventCommandHandler
+            .deleteVolunteerEventWaitingQueueByVolunteerEventId(
+                volunteerEventId = volunteerEventId
+            )
+    }
 }

--- a/src/infrastructure/storage/src/main/kotlin/yapp/be/storage/jpa/volunteerevent/repository/VolunteerEventJpaRepository.kt
+++ b/src/infrastructure/storage/src/main/kotlin/yapp/be/storage/jpa/volunteerevent/repository/VolunteerEventJpaRepository.kt
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import yapp.be.model.enums.volunteerevent.VolunteerEventStatus
 import yapp.be.storage.jpa.volunteerevent.model.VolunteerEventEntity
 import yapp.be.storage.jpa.volunteerevent.repository.querydsl.VolunteerEventJpaRepositoryCustom
+import java.time.LocalDateTime
 
 interface VolunteerEventJpaRepository : JpaRepository<VolunteerEventEntity, Long>, VolunteerEventJpaRepositoryCustom {
     fun findAllByShelterId(shelterId: Long): List<VolunteerEventEntity>
@@ -14,4 +15,5 @@ interface VolunteerEventJpaRepository : JpaRepository<VolunteerEventEntity, Long
 
     fun findAllByShelterId(shelterId: Long, pageable: Pageable): Page<VolunteerEventEntity>
     fun findByIdAndShelterIdAndDeletedIsFalse(id: Long, shelterId: Long): VolunteerEventEntity?
+    fun findByEndAtBeforeAndStatusNot(today: LocalDateTime, status: VolunteerEventStatus): List<VolunteerEventEntity>
 }

--- a/src/infrastructure/storage/src/main/kotlin/yapp/be/storage/jpa/volunteerevent/repository/VolunteerEventWaitingQueueJpaRepository.kt
+++ b/src/infrastructure/storage/src/main/kotlin/yapp/be/storage/jpa/volunteerevent/repository/VolunteerEventWaitingQueueJpaRepository.kt
@@ -12,4 +12,5 @@ interface VolunteerEventWaitingQueueJpaRepository : JpaRepository<VolunteerEvent
     fun findAllByVolunteerEventIdIn(volunteerEventIds: Collection<Long>): List<VolunteerEventWaitingQueueEntity>
 
     fun deleteByVolunteerIdAndVolunteerEventId(volunteerId: Long, volunteerEventId: Long)
+    fun deleteByVolunteerEventId(volunteerEventId: Long)
 }

--- a/src/infrastructure/storage/src/main/kotlin/yapp/be/storage/repository/command/VolunteerEventCommandRepository.kt
+++ b/src/infrastructure/storage/src/main/kotlin/yapp/be/storage/repository/command/VolunteerEventCommandRepository.kt
@@ -64,6 +64,11 @@ class VolunteerEventCommandRepository(
                 volunteerEventId = volunteerEventId
             )
     }
+
+    override fun deleteVolunteerEventWaitingQueueByVolunteerEventId(volunteerEventId: Long) {
+        return volunteerEventWaitingQueueJpaRepository.deleteByVolunteerEventId(volunteerEventId)
+    }
+
     override fun deleteVolunteerEventWaitingQueueByVolunteerIdAndVolunteerEventId(volunteerId: Long, volunteerEventId: Long) {
         return volunteerEventWaitingQueueJpaRepository.deleteByVolunteerIdAndVolunteerEventId(
             volunteerId = volunteerId,

--- a/src/infrastructure/storage/src/main/kotlin/yapp/be/storage/repository/query/VolunteerEventQueryRepository.kt
+++ b/src/infrastructure/storage/src/main/kotlin/yapp/be/storage/repository/query/VolunteerEventQueryRepository.kt
@@ -49,6 +49,13 @@ class VolunteerEventQueryRepository(
         )
     }
 
+    override fun findVolunteerEventDone(): List<VolunteerEvent> {
+        return volunteerEventJpaRepository.findByEndAtBeforeAndStatusNot(
+            LocalDateTime.now(),
+            VolunteerEventStatus.DONE
+        ).map { it.toDomainModel() }
+    }
+
     override fun findShelterUserStatByShelterId(shelterId: Long): ShelterUserVolunteerEventStatDto {
         val volunteerEventEntities =
             volunteerEventJpaRepository.findAllByShelterId(shelterId)
@@ -70,6 +77,11 @@ class VolunteerEventQueryRepository(
             type = StorageExceptionType.ENTITY_NOT_FOUND,
             message = "봉사 정보를 찾을 수 없습니다."
         )
+    }
+
+    override fun findById(id: Long): VolunteerEvent {
+        val volunteerEventEntity = volunteerEventJpaRepository.findById(id).orElseThrow { throw CustomException(StorageExceptionType.ENTITY_NOT_FOUND, "해당 사용자가 존재하지 않습니다.") }
+        return volunteerEventEntity.toDomainModel()
     }
 
     override fun findAllShelterVolunteerEventByShelterId(


### PR DESCRIPTION
<!--
1. 어떤 작업을 했는지 : 간단하게 설명
2. 자세한 설명 : 필요하다면
3. 영향범위 : 영향받은 모듈
4. 데이터베이스 DDL 변경사항이 필요하다면 반드시 SQL을 작성해주세요
-->

## 🎯 작업 내역
- 스케쥴러를 활용
- 전날 완료된 봉사 이벤트 Done으로 상태 변경
- 해당 이벤트 대기큐 삭제
## 📜 Jira 티켓
[YW2-190](https://yapp22-web2.atlassian.net/browse/YW2-190)
## 📁 영향범위 (모듈)
- api
- storage
- volunteerEvent
## 📒 SQL (DDL 변경사항 있는 경우만)

_---
Resolves: # See also: #_
