### PR TITLE
[YW2-245] 메일 컬러 변경

### DIFF
--- a/src/domain/src/main/kotlin/yapp/be/domain/common/service/MailSenderRegistry.kt
+++ b/src/domain/src/main/kotlin/yapp/be/domain/common/service/MailSenderRegistry.kt
@@ -1,6 +1,0 @@
-package yapp.be.domain.common.service
-
-import org.springframework.stereotype.Component
-
-@Component
-class MailSenderRegistry

--- a/src/domain/src/main/kotlin/yapp/be/domain/common/service/MailSenderRegistry.kt
+++ b/src/domain/src/main/kotlin/yapp/be/domain/common/service/MailSenderRegistry.kt
@@ -1,0 +1,6 @@
+package yapp.be.domain.common.service
+
+import org.springframework.stereotype.Component
+
+@Component
+class MailSenderRegistry

--- a/src/support/mail/src/main/resources/templates/reset-password.html
+++ b/src/support/mail/src/main/resources/templates/reset-password.html
@@ -113,8 +113,8 @@
                                     <tr>
                                         <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 10px 30px;font-family:'Raleway',sans-serif;" align="left">
                                             <p style="text-align: center;">재 설정된 비밀번호는 아래와 같습니다. </p>
-                                            <p style="text-align: center;">비밀번호 로그인 이후, 꼭 변경해주세요 </p>
-                                            <p style="display: block; width: 150px; height: 50px; margin: 20px auto; background-color: #007BFF; text-align: center; border-radius: 4px; color: white; font-weight: bold; line-height: 50px; text-decoration: none;">[[${password}]]</p>
+                                            <p style="text-align: center;">로그인 이후, 꼭 비빌먼호를 변경해주세요 </p>
+                                            <p style="display: block; width: 150px; height: 50px; margin: 20px auto; background-color: #FE5555; text-align: center; border-radius: 4px; color: white; font-weight: bold; line-height: 50px; text-decoration: none;">[[${password}]]</p>
                                         </td>
                                     </tr>
                                     </tbody>


### PR DESCRIPTION
<!--
1. 어떤 작업을 했는지 : 간단하게 설명
2. 자세한 설명 : 필요하다면
3. 영향범위 : 영향받은 모듈
4. 데이터베이스 DDL 변경사항이 필요하다면 반드시 SQL을 작성해주세요
-->

## 🎯 작업 내역
- 메일의 컬러를 대표색으로변경 (파랑 -> 주황) 
## 📜 Jira 티켓
https://yapp22-web2.atlassian.net/jira/software/projects/YW2/boards/3?selectedIssue=YW2-245

## 📁 영향범위 (모듈)

## 📒 SQL (DDL 변경사항 있는 경우만)

_---
Resolves: # See also: #_
